### PR TITLE
Feature: Add Measure Form Modal

### DIFF
--- a/src/actions/addMeasure.ts
+++ b/src/actions/addMeasure.ts
@@ -1,0 +1,24 @@
+interface UploadPayload {
+  image: string
+  customer_code: string
+  measure_datetime: Date
+  measure_type: 'WATER' | 'GAS'
+}
+
+export async function uploadMeasurement(
+  data: UploadPayload,
+): Promise<Response> {
+  const response = await fetch('http://localhost:8080/api/measures/upload', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+  })
+
+  if (!response.ok) {
+    throw new Error(`Failed to upload: ${response.statusText}`)
+  }
+
+  return response
+}

--- a/src/actions/uploadImage.ts
+++ b/src/actions/uploadImage.ts
@@ -1,0 +1,13 @@
+export async function convertImageToBase64(imageFile: File): Promise<string> {
+  try {
+    // Leitura da imagem em base64
+    const buffer = await imageFile.arrayBuffer()
+    const base64String = Buffer.from(buffer).toString('base64')
+
+    // Formatar o resultado como uma string base64
+    const mimeType = imageFile.type
+    return `data:${mimeType};base64,${base64String}`
+  } catch {
+    throw new Error('Error converting image to base64')
+  }
+}

--- a/src/components/chart/chart-measurement.tsx
+++ b/src/components/chart/chart-measurement.tsx
@@ -17,19 +17,8 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from '@/components/ui/chart'
-import { Button } from '../ui/button'
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '../ui/dialog'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { DatePicker } from '../date-picker/date-picker'
-import { RadioGroup, RadioGroupItem } from '../ui/radio-group'
+
+import { MeasureModal } from '../measure-modal/measure-modal'
 
 export const description = 'A multiple bar chart'
 
@@ -61,48 +50,7 @@ export function ChartMeasurement() {
           <CardTitle>Bar Chart - Multiple</CardTitle>
           <CardDescription>January - June 2024</CardDescription>
         </div>
-        <Dialog>
-          <DialogTrigger asChild>
-            <Button variant="outline">+ Measure</Button>
-          </DialogTrigger>
-          <DialogContent className="w-fit sm:max-w-[425px]">
-            <DialogHeader>
-              <DialogTitle>Add measure</DialogTitle>
-            </DialogHeader>
-            <div className="flex flex-col gap-4 py-4">
-              <div className="flex flex-col items-start gap-4">
-                <Label htmlFor="measure-image" className="text-left">
-                  Measure Image
-                </Label>
-                <Input id="measure-image" type="file" className="w-[240px]" />
-              </div>
-              <div className="flex flex-col items-start gap-4">
-                <Label htmlFor="date" className="text-left">
-                  Date
-                </Label>
-                <DatePicker />
-              </div>
-              <div className="flex flex-col items-start gap-4">
-                <Label htmlFor="date" className="text-left">
-                  Measurer Type
-                </Label>
-                <RadioGroup defaultValue="option-one">
-                  <div className="flex items-center space-x-2">
-                    <RadioGroupItem value="option-one" id="option-one" />
-                    <Label htmlFor="option-one">Water</Label>
-                  </div>
-                  <div className="flex items-center space-x-2">
-                    <RadioGroupItem value="option-two" id="option-two" />
-                    <Label htmlFor="option-two">Gas</Label>
-                  </div>
-                </RadioGroup>
-              </div>
-            </div>
-            <DialogFooter>
-              <Button type="submit">Save changes</Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
+        <MeasureModal />
       </CardHeader>
       <CardContent>
         <ChartContainer config={chartConfig}>

--- a/src/components/measure-modal/add-measure.tsx
+++ b/src/components/measure-modal/add-measure.tsx
@@ -25,6 +25,7 @@ import {
 import { Input } from '@/components/ui/input'
 import { RadioGroup, RadioGroupItem } from '../ui/radio-group'
 import { convertImageToBase64 } from '@/actions/uploadImage'
+import { uploadMeasurement } from '@/actions/addMeasure'
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
 const ACCEPTED_IMAGE_TYPES = [
@@ -45,7 +46,7 @@ const formSchema = z.object({
   measure_datetime: z.date({
     required_error: 'A date of birth is required.',
   }),
-  measure_type: z.enum(['water', 'gas'], {
+  measure_type: z.enum(['WATER', 'GAS'], {
     required_error: 'You need to select a measurer type.',
   }),
 })
@@ -57,7 +58,11 @@ export function AddMeasureForm() {
   async function onSubmit(values: z.infer<typeof formSchema>) {
     try {
       const imageBase64 = await convertImageToBase64(values.image)
-      console.log({ ...values, image: imageBase64 })
+      await uploadMeasurement({
+        ...values,
+        customer_code: '1',
+        image: imageBase64,
+      })
       // Aqui você pode enviar os dados para o servidor
     } catch (error) {
       console.error('Error converting image:', error)
@@ -149,13 +154,13 @@ export function AddMeasureForm() {
                 >
                   <FormItem className="flex items-center space-x-3 space-y-0">
                     <FormControl>
-                      <RadioGroupItem value="water" />
+                      <RadioGroupItem value="WATER" />
                     </FormControl>
                     <FormLabel className="font-normal">Water</FormLabel>
                   </FormItem>
                   <FormItem className="flex items-center space-x-3 space-y-0">
                     <FormControl>
-                      <RadioGroupItem value="gas" />
+                      <RadioGroupItem value="GAS" />
                     </FormControl>
                     <FormLabel className="font-normal">Gas</FormLabel>
                   </FormItem>

--- a/src/components/measure-modal/add-measure.tsx
+++ b/src/components/measure-modal/add-measure.tsx
@@ -1,0 +1,174 @@
+'use client'
+
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { CalendarIcon } from '@radix-ui/react-icons'
+import { format } from 'date-fns'
+import { cn } from '@/lib/utils'
+
+import { Button } from '@/components/ui/button'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form'
+import { Calendar } from '@/components/ui/calendar'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import { Input } from '@/components/ui/input'
+import { RadioGroup, RadioGroupItem } from '../ui/radio-group'
+import { convertImageToBase64 } from '@/actions/uploadImage'
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
+const ACCEPTED_IMAGE_TYPES = [
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+  'image/webp',
+]
+
+const formSchema = z.object({
+  image: z
+    .instanceof(File)
+    .refine((file) => file.size <= MAX_FILE_SIZE, `Max file size is 5MB.`)
+    .refine(
+      (file) => ACCEPTED_IMAGE_TYPES.includes(file.type),
+      'Only .jpg, .jpeg, .png and .webp formats are supported.',
+    ),
+  measure_datetime: z.date({
+    required_error: 'A date of birth is required.',
+  }),
+  measure_type: z.enum(['water', 'gas'], {
+    required_error: 'You need to select a measurer type.',
+  }),
+})
+
+export function AddMeasureForm() {
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+  })
+  async function onSubmit(values: z.infer<typeof formSchema>) {
+    try {
+      const imageBase64 = await convertImageToBase64(values.image)
+      console.log({ ...values, image: imageBase64 })
+      // Aqui você pode enviar os dados para o servidor
+    } catch (error) {
+      console.error('Error converting image:', error)
+      // Trate o erro adequadamente (por exemplo, mostrando uma mensagem ao usuário)
+    }
+  }
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="space-y-8 flex flex-col"
+      >
+        <FormField
+          control={form.control}
+          name="image"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Measure Image</FormLabel>
+              <FormControl>
+                <Input
+                  className="w-[240px]"
+                  type="file"
+                  accept={ACCEPTED_IMAGE_TYPES.join(',')}
+                  onChange={(e) => {
+                    const file = e.target.files?.[0]
+                    if (file) {
+                      field.onChange(file)
+                    }
+                  }}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="measure_datetime"
+          render={({ field }) => (
+            <FormItem className="flex flex-col">
+              <FormLabel>Date</FormLabel>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <FormControl>
+                    <Button
+                      variant={'outline'}
+                      className={cn(
+                        'w-[240px] pl-3 text-left font-normal',
+                        !field.value && 'text-muted-foreground',
+                      )}
+                    >
+                      {field.value ? (
+                        format(field.value, 'PPP')
+                      ) : (
+                        <span>Pick a date</span>
+                      )}
+                      <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+                    </Button>
+                  </FormControl>
+                </PopoverTrigger>
+                <PopoverContent className="w-auto p-0" align="start">
+                  <Calendar
+                    mode="single"
+                    selected={field.value}
+                    onSelect={field.onChange}
+                    disabled={(date) =>
+                      date > new Date() || date < new Date('1900-01-01')
+                    }
+                    initialFocus
+                  />
+                </PopoverContent>
+              </Popover>
+
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="measure_type"
+          render={({ field }) => (
+            <FormItem className="space-y-3">
+              <FormLabel>Measurer Type</FormLabel>
+              <FormControl>
+                <RadioGroup
+                  onValueChange={field.onChange}
+                  defaultValue={field.value}
+                  className="flex flex-col space-y-1"
+                >
+                  <FormItem className="flex items-center space-x-3 space-y-0">
+                    <FormControl>
+                      <RadioGroupItem value="water" />
+                    </FormControl>
+                    <FormLabel className="font-normal">Water</FormLabel>
+                  </FormItem>
+                  <FormItem className="flex items-center space-x-3 space-y-0">
+                    <FormControl>
+                      <RadioGroupItem value="gas" />
+                    </FormControl>
+                    <FormLabel className="font-normal">Gas</FormLabel>
+                  </FormItem>
+                </RadioGroup>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" className="self-end">
+          Submit
+        </Button>
+      </form>
+    </Form>
+  )
+}

--- a/src/components/measure-modal/measure-modal.tsx
+++ b/src/components/measure-modal/measure-modal.tsx
@@ -1,0 +1,25 @@
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { AddMeasureForm } from './add-measure'
+
+export function MeasureModal() {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="outline">+ Measure</Button>
+      </DialogTrigger>
+      <DialogContent className="w-fit sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Add measure</DialogTitle>
+        </DialogHeader>
+        <AddMeasureForm />
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
### Description

This pull request introduces the feature to add a new measurement through a modal. The modal allows users to upload an image, convert it to a base64 string, and submit the measurement data.

### Changes Made

- **feat**: Added function to convert image files to base64 format for easy processing.
- **feat**: Created an "Add Measure" form modal to allow users to input new measurements.
- **feat**: Created a measure modal for uploading and managing measurement data.
- **feat**: Added `uploadMeasurement` function to handle the backend request for adding new measurements.

### Next Steps

- Test the form modal for various use cases.
- Ensure the image upload and conversion to base64 work as expected.
